### PR TITLE
Add granite 4.1 language models

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ https://huggingface.co/ibm-granite/granite-guardian-3.3-8b
 
 quay.io/redhat-ai-services/modelcar-catalog:granite-guardian-3.3-8b
 
+### granite-guardian-4.1-8b
+
+https://huggingface.co/ibm-granite/granite-guardian-4.1-8b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-guardian-4.1-8b
+
 ### gemma-7b
 
 https://huggingface.co/google/gemma-7b

--- a/README.md
+++ b/README.md
@@ -196,6 +196,24 @@ https://huggingface.co/ibm-granite/granite-4.0-h-micro
 
 quay.io/redhat-ai-services/modelcar-catalog:granite-4.0-h-micro
 
+### granite-4.1-3b
+
+https://huggingface.co/ibm-granite/granite-4.1-3b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-3b
+
+### granite-4.1-8b
+
+https://huggingface.co/ibm-granite/granite-4.1-8b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-8b
+
+### granite-4.1-30b
+
+https://huggingface.co/ibm-granite/granite-4.1-30b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-30b
+
 ### granite-embedding-english-r2
 
 https://huggingface.co/ibm-granite/granite-embedding-english-r2

--- a/modelcar-images/ibm-granite/granite-4.1-30b/Containerfile
+++ b/modelcar-images/ibm-granite/granite-4.1-30b/Containerfile
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
+
+# Copy the model files in multiple layers to avoid large image issues
+COPY models/*.json /models/
+COPY models/*.txt /models/
+COPY models/*.jinja /models/
+COPY models/model-00001-of-00012.safetensors /models/
+COPY models/model-00002-of-00012.safetensors /models/
+COPY models/model-00003-of-00012.safetensors /models/
+COPY models/model-00004-of-00012.safetensors /models/
+COPY models/model-00005-of-00012.safetensors /models/
+COPY models/model-00006-of-00012.safetensors /models/
+COPY models/model-00007-of-00012.safetensors /models/
+COPY models/model-00008-of-00012.safetensors /models/
+COPY models/model-00009-of-00012.safetensors /models/
+COPY models/model-00010-of-00012.safetensors /models/
+COPY models/model-00011-of-00012.safetensors /models/
+COPY models/model-00012-of-00012.safetensors /models/
+
+# Set the user to 1001
+USER 1001

--- a/modelcar-images/ibm-granite/granite-4.1-30b/README.md
+++ b/modelcar-images/ibm-granite/granite-4.1-30b/README.md
@@ -1,0 +1,42 @@
+# granite-4.1-30b
+
+https://huggingface.co/ibm-granite/granite-4.1-30b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-30b
+
+## Building Image
+
+This ModelCar build downloads the model locally then copies the files to a container in multiple layers to avoid podman memory issues.
+
+### Downloading model files locally
+
+```
+mkdir -p ./modelcar-images/ibm-granite/granite-4.1-30b/models
+podman run --rm --platform linux/amd64 \
+    -v ./modelcar-images/ibm-granite/granite-4.1-30b/models:/models \
+    --env-file modelcar-images/ibm-granite/granite-4.1-30b/downloader.env \
+    quay.io/redhat-ai-services/huggingface-downloader:latest
+```
+
+### Building the ModelCar Image
+
+```
+podman build modelcar-images/ibm-granite/granite-4.1-30b \
+    -t quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-30b  \
+    --platform linux/amd64
+```
+
+## Deploying Model
+
+This model can be deployed using vLLM on OpenShift AI using the following Helm Chart.
+
+```
+helm repo add redhat-ai-services https://redhat-ai-services.github.io/helm-charts/
+helm repo update redhat-ai-services
+helm upgrade -i granite-41-30b redhat-ai-services/vllm-kserve \
+    --values modelcar-images/ibm-granite/granite-4.1-30b/values.yaml
+```
+
+For more information on the above Helm Chart, you can find the source code for that chart here:
+
+https://github.com/redhat-ai-services/helm-charts/tree/main/charts/vllm-kserve

--- a/modelcar-images/ibm-granite/granite-4.1-30b/downloader.env
+++ b/modelcar-images/ibm-granite/granite-4.1-30b/downloader.env
@@ -1,0 +1,1 @@
+MODEL_REPO=ibm-granite/granite-4.1-30b

--- a/modelcar-images/ibm-granite/granite-4.1-30b/values.yaml
+++ b/modelcar-images/ibm-granite/granite-4.1-30b/values.yaml
@@ -1,0 +1,3 @@
+model:
+  mode: uri
+  uri: oci://quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-30b

--- a/modelcar-images/ibm-granite/granite-4.1-3b/Containerfile
+++ b/modelcar-images/ibm-granite/granite-4.1-3b/Containerfile
@@ -1,0 +1,17 @@
+# Base image for the modelcar Granite image
+FROM quay.io/redhat-ai-services/huggingface-downloader:latest as base
+
+# The model repo to download
+ENV MODEL_REPO="ibm-granite/granite-4.1-3b"
+
+# Download the necessary model files
+RUN python3 download_model.py --model-repo ${MODEL_REPO}
+
+# Final image containing only the essential model files
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
+
+# Copy only the necessary model files from the base image
+COPY --from=base /models /models
+
+# Set the user to 1001
+USER 1001

--- a/modelcar-images/ibm-granite/granite-4.1-3b/README.md
+++ b/modelcar-images/ibm-granite/granite-4.1-3b/README.md
@@ -1,0 +1,30 @@
+# granite-4.1-3b
+
+https://huggingface.co/ibm-granite/granite-4.1-3b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-3b
+
+## Building Image
+
+```
+podman build modelcar-images/ibm-granite/granite-4.1-3b \
+    -t quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-3b  \
+    --platform linux/amd64
+```
+
+## Deploying Model
+
+This model can be deployed using vLLM on OpenShift AI using the following Helm Chart.
+
+This configuration includes some specific configurations to deploy it on an NVIDIA A10G, which may require changes for your specific GPU.
+
+```
+helm repo add redhat-ai-services https://redhat-ai-services.github.io/helm-charts/
+helm repo update redhat-ai-services
+helm upgrade -i granite-41-3b redhat-ai-services/vllm-kserve \
+    --values modelcar-images/ibm-granite/granite-4.1-3b/values.yaml
+```
+
+For more information on the above Helm Chart, you can find the source code for that chart here:
+
+https://github.com/redhat-ai-services/helm-charts/tree/main/charts/vllm-kserve

--- a/modelcar-images/ibm-granite/granite-4.1-3b/values.yaml
+++ b/modelcar-images/ibm-granite/granite-4.1-3b/values.yaml
@@ -1,0 +1,3 @@
+model:
+  mode: uri
+  uri: oci://quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-3b

--- a/modelcar-images/ibm-granite/granite-4.1-8b/Containerfile
+++ b/modelcar-images/ibm-granite/granite-4.1-8b/Containerfile
@@ -1,0 +1,17 @@
+# Base image for the modelcar Granite image
+FROM quay.io/redhat-ai-services/huggingface-downloader:latest as base
+
+# The model repo to download
+ENV MODEL_REPO="ibm-granite/granite-4.1-8b"
+
+# Download the necessary model files
+RUN python3 download_model.py --model-repo ${MODEL_REPO}
+
+# Final image containing only the essential model files
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
+
+# Copy only the necessary model files from the base image
+COPY --from=base /models /models
+
+# Set the user to 1001
+USER 1001

--- a/modelcar-images/ibm-granite/granite-4.1-8b/README.md
+++ b/modelcar-images/ibm-granite/granite-4.1-8b/README.md
@@ -1,0 +1,30 @@
+# granite-4.1-8b
+
+https://huggingface.co/ibm-granite/granite-4.1-8b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-8b
+
+## Building Image
+
+```
+podman build modelcar-images/ibm-granite/granite-4.1-8b \
+    -t quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-8b  \
+    --platform linux/amd64
+```
+
+## Deploying Model
+
+This model can be deployed using vLLM on OpenShift AI using the following Helm Chart.
+
+This configuration includes some specific configurations to deploy it on an NVIDIA A10G, which may require changes for your specific GPU.
+
+```
+helm repo add redhat-ai-services https://redhat-ai-services.github.io/helm-charts/
+helm repo update redhat-ai-services
+helm upgrade -i granite-41-8b redhat-ai-services/vllm-kserve \
+    --values modelcar-images/ibm-granite/granite-4.1-8b/values.yaml
+```
+
+For more information on the above Helm Chart, you can find the source code for that chart here:
+
+https://github.com/redhat-ai-services/helm-charts/tree/main/charts/vllm-kserve

--- a/modelcar-images/ibm-granite/granite-4.1-8b/values.yaml
+++ b/modelcar-images/ibm-granite/granite-4.1-8b/values.yaml
@@ -1,0 +1,3 @@
+model:
+  mode: uri
+  uri: oci://quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-8b

--- a/modelcar-images/ibm-granite/granite-guardian-4.1-8b/Containerfile
+++ b/modelcar-images/ibm-granite/granite-guardian-4.1-8b/Containerfile
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
+
+# Copy the model files in multiple layers to avoid large image issues
+COPY models/*.json /models/
+COPY models/*.txt /models/
+COPY models/*.jinja /models/
+COPY models/model-00001-of-00004.safetensors /models/
+COPY models/model-00002-of-00004.safetensors /models/
+COPY models/model-00003-of-00004.safetensors /models/
+COPY models/model-00004-of-00004.safetensors /models/
+
+# Set the user to 1001
+USER 1001

--- a/modelcar-images/ibm-granite/granite-guardian-4.1-8b/README.md
+++ b/modelcar-images/ibm-granite/granite-guardian-4.1-8b/README.md
@@ -1,0 +1,44 @@
+# granite-guardian-4.1-8b
+
+https://huggingface.co/ibm-granite/granite-guardian-4.1-8b
+
+quay.io/redhat-ai-services/modelcar-catalog:granite-guardian-4.1-8b
+
+## Building Image
+
+This ModelCar build downloads the model locally then copies the files to a container in multiple layers to avoid podman memory issues.
+
+### Downloading model files locally
+
+```
+mkdir -p ./modelcar-images/ibm-granite/granite-guardian-4.1-8b/models
+podman run --rm --platform linux/amd64 \
+    -v ./modelcar-images/ibm-granite/granite-guardian-4.1-8b/models:/models \
+    --env-file modelcar-images/ibm-granite/granite-guardian-4.1-8b/downloader.env \
+    quay.io/redhat-ai-services/huggingface-downloader:latest
+```
+
+### Building the ModelCar Image
+
+```
+podman build modelcar-images/ibm-granite/granite-guardian-4.1-8b \
+    -t quay.io/redhat-ai-services/modelcar-catalog:granite-guardian-4.1-8b  \
+    --platform linux/amd64
+```
+
+## Deploying Model
+
+This model can be deployed using vLLM on OpenShift AI using the following Helm Chart.
+
+This configuration includes some specific configurations to deploy it on an NVIDIA A10G, which may require changes for your specific GPU.
+
+```
+helm repo add redhat-ai-services https://redhat-ai-services.github.io/helm-charts/
+helm repo update redhat-ai-services
+helm upgrade -i granite-guardian-41-8b redhat-ai-services/vllm-kserve \
+    --values modelcar-images/ibm-granite/granite-guardian-4.1-8b/values.yaml
+```
+
+For more information on the above Helm Chart, you can find the source code for that chart here:
+
+https://github.com/redhat-ai-services/helm-charts/tree/main/charts/vllm-kserve

--- a/modelcar-images/ibm-granite/granite-guardian-4.1-8b/downloader.env
+++ b/modelcar-images/ibm-granite/granite-guardian-4.1-8b/downloader.env
@@ -1,0 +1,1 @@
+MODEL_REPO=ibm-granite/granite-guardian-4.1-8b

--- a/modelcar-images/ibm-granite/granite-guardian-4.1-8b/values.yaml
+++ b/modelcar-images/ibm-granite/granite-guardian-4.1-8b/values.yaml
@@ -1,0 +1,3 @@
+model:
+  mode: uri
+  uri: oci://quay.io/redhat-ai-services/modelcar-catalog:granite-guardian-4.1-8b


### PR DESCRIPTION
Granite 4.1 has been released, so I added them by referencing the existing code in this repository.

The 30B model was too heavy to test on my local environment, but I confirmed that the 3B version can be built:

```
podman build modelcar-images/ibm-granite/granite-4.1-3b \
    -t quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-3b  \
    --platform linux/amd64
[1/2] STEP 1/3: FROM quay.io/redhat-ai-services/huggingface-downloader:latest AS base
[1/2] STEP 2/3: ENV MODEL_REPO="ibm-granite/granite-4.1-3b"
--> Using cache 824919e21cda03361d8d58872e7bddaf5533fc539f457a861fd54f627ef8dfdb
--> 824919e21cda
[1/2] STEP 3/3: RUN python3 download_model.py --model-repo ${MODEL_REPO}
Attempting to download the following model from huggingface: ibm-granite/granite-4.1-3b
Target director: ./models
With allow-patterns: ['*.safetensors', '*.json', '*.txt', '*.sig', '*.jinja']
Fetching 12 files: 100%|██████████| 12/12 [01:32<00:00,  7.72s/it]
--> 4025022652e6
[2/2] STEP 1/3: FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
Trying to pull registry.access.redhat.com/ubi9/ubi-micro:9.8...
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:0041f61dcf11a311c2ecd8ab448db7104c6b7c8d8eecd1f1224ebc36f4e6e673
Copying config sha256:e541beeef9ea4c64e47202eeccfd5f2da17d7aeb53fba08d42df021f1d9f6e5b
Writing manifest to image destination
Storing signatures
[2/2] STEP 2/3: COPY --from=base /models /models
--> 145592e8269f
[2/2] STEP 3/3: USER 1001
[2/2] COMMIT quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-3b
--> 4749918532f9
Successfully tagged quay.io/redhat-ai-services/modelcar-catalog:granite-4.1-3b
```